### PR TITLE
Updating MariaDB version and upgrading puppetlabs-apt dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     'stdlib':
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.1'
+      ref: '4.5.0'
     'apt':
       repo: 'https://github.com/puppetlabs/puppetlabs-apt.git'
-      ref: '1.7.0'
+      ref: '2.0.0'
   symlinks:
     "mariadbrepo": "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,8 +79,10 @@ class mariadbrepo (
         location   => "${mirror}/repo/${version}/${os}",
         release    => $::lsbdistcodename,
         repos      => 'main',
-        key        => '1BB943DB',
-        key_server => 'keyserver.ubuntu.com',
+        key      => {
+            'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
+            'server' => 'keyserver.ubuntu.com',
+        }
       }
     }
     default: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,14 +75,14 @@ class mariadbrepo (
     }
     'Debian','Ubuntu': {
       apt::source { 'MariaDB':
-        ensure     => $ensure,
-        location   => "${mirror}/repo/${version}/${os}",
-        release    => $::lsbdistcodename,
-        repos      => 'main',
+        ensure   => $ensure,
+        location => "${mirror}/repo/${version}/${os}",
+        release  => $::lsbdistcodename,
+        repos    => 'main',
         key      => {
-            'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
-            'server' => 'keyserver.ubuntu.com',
-        }
+          'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
+          'server' => 'keyserver.ubuntu.com',
+        },
       }
     }
     default: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,8 @@
 #
 # [*version*]
 #   (float) MariaDB version number
-#   Possible value: 5.5, 10.0
-#   Default: 10.0
+#   Possible value: 5.5, 10.1
+#   Default: 10.1
 #
 # === Examples
 #
@@ -39,7 +39,7 @@
 class mariadbrepo (
   $ensure  = 'present',
   $mirror  = 'http://ftp.osuosl.org/pub/mariadb',
-  $version = '10.0',
+  $version = '10.1',
 ) {
 
   $os = $::operatingsystem ? {

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.2.1 < 5.0.0"
+      "version_requirement": ">= 4.5.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 2.0.0"
     }
   ]
 }

--- a/spec/classes/mariadbrepo_spec.rb
+++ b/spec/classes/mariadbrepo_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'mariadbrepo' do
 
   ['Fedora', 'RedHat', 'CentOS', 'Debian', 'Ubuntu'].each do |operatingsystem|
-    ['5.5', '10.0'].each do |mariadb_release|
+    ['5.5', '10.1'].each do |mariadb_release|
       ['i386', 'x86_64'].each do |architecture|
         ['present', 'absent'].each do |package_ensure|
 
@@ -68,12 +68,14 @@ describe 'mariadbrepo' do
             when
               it {
                 should contain_apt__source('MariaDB').with({
-                  'ensure'     => package_ensure,
-                  'location'   => "http://ftp.osuosl.org/pub/mariadb/repo/#{mariadb_release}/#{os}",
-                  'release'    => "#{codename}",
-                  'repos'      => 'main',
-                  'key'        => '1BB943DB',
-                  'key_server' => 'keyserver.ubuntu.com',
+                  'ensure'   => package_ensure,
+                  'location' => "http://ftp.osuosl.org/pub/mariadb/repo/#{mariadb_release}/#{os}",
+                  'release'  => "#{codename}",
+                  'repos'    => 'main',
+                  'key'      => {
+                    'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
+                    'server' => 'keyserver.ubuntu.com',
+                  },
                 })
               }
             end


### PR DESCRIPTION
We have dependency issues when installing this because most of the modules updated their dependency with puppetlabs-apt. 

I also updated the MariaDB default version to the latest one.
