### PR TITLE
Updating puppetlabs-apt module dependencies to latest stable

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     'stdlib':
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.1'
+      ref: '4.9.0'
     'apt':
       repo: 'https://github.com/puppetlabs/puppetlabs-apt.git'
-      ref: '1.7.0'
+      ref: '2.2.0'
   symlinks:
     "mariadbrepo": "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/fixtures/
 .bundle/
 coverage/
 *.sw*
+log/

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@
 #
 # Yanis Guenane <yguenane@gmail.com>
 # Dimitri Savineau <savineau.dimitri@gmail.com>
-# Alberto Varela Sánchez <alberto@berriart.com>
+# Alberto Varela Sanchez <alberto@berriart.com>
 #
 # === Copyright
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@
 #
 # Yanis Guenane <yguenane@gmail.com>
 # Dimitri Savineau <savineau.dimitri@gmail.com>
+# Alberto Varela Sánchez <alberto@berriart.com>
 #
 # === Copyright
 #
@@ -75,12 +76,14 @@ class mariadbrepo (
     }
     'Debian','Ubuntu': {
       apt::source { 'MariaDB':
-        ensure     => $ensure,
-        location   => "${mirror}/repo/${version}/${os}",
-        release    => $::lsbdistcodename,
-        repos      => 'main',
-        key        => '1BB943DB',
-        key_server => 'keyserver.ubuntu.com',
+        ensure   => $ensure,
+        location => "${mirror}/repo/${version}/${os}",
+        release  => $::lsbdistcodename,
+        repos    => 'main',
+        key      => {
+          'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
+          'server' => 'keyserver.ubuntu.com',
+        },
       }
     }
     default: {

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     }
   ],
   "name": "yguenane-mariadbrepo",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "source": "https://github.com/Mylezeem/puppet-mariadbrepo",
   "author": "Yanis Guenane",
   "license": "Apache-2.0",
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 2.2.0 < 3.0.0"
     }
   ]
 }

--- a/spec/acceptance/basic_spec.rb
+++ b/spec/acceptance/basic_spec.rb
@@ -16,8 +16,14 @@ describe 'mariadbrepo class' do
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe yumrepo('MariaDB') do
-      it { should be_enabled }
+    case fact('osfamily')
+      when 'RedHat'
+        describe yumrepo('MariaDB') do
+          it { should be_enabled }
+        end
+      when 'Debian'
+        # No equivalent resource type for apt
+        # http://serverspec.org/resource_types.html
     end
 
     describe file(repofile) do
@@ -32,15 +38,23 @@ describe 'mariadbrepo class' do
       when 'Debian'
         repofile = '/etc/apt/sources.list.d/MariaDB.list'
     end
+
     it 'should work with no errors' do
       pp = 'class { \'::mariadbrepo\': version => \'5.5\' }'
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe yumrepo('MariaDB') do
-      it { should be_enabled }
+    case fact('osfamily')
+      when 'RedHat'
+        describe yumrepo('MariaDB') do
+          it { should be_enabled }
+        end
+      when 'Debian'
+        # No equivalent resource type for apt
+        # http://serverspec.org/resource_types.html
     end
+
     describe file(repofile) do
       its(:content) { should match /5.5/ }
     end

--- a/spec/classes/mariadbrepo_spec.rb
+++ b/spec/classes/mariadbrepo_spec.rb
@@ -14,20 +14,25 @@ describe 'mariadbrepo' do
               os        = 'fedora'
               vers_maj  = '20'
               vers_full = '20'
+              osfamily  = 'RedHat'
             when 'RedHat'
               os        = 'rhel'
               vers_maj  = '6'
               vers_full = '6.5'
+              osfamily  = 'RedHat'
             when 'CentOS'
               os        = 'centos'
               vers_maj  = '6'
               vers_full = '6.5'
+              osfamily  = 'RedHat'
             when 'Debian'
               os        = 'debian'
               codename  = 'wheezy'
+              osfamily  = 'Debian'
             when 'Ubuntu'
               os        = 'ubuntu'
               codename  = 'precise'
+              osfamily  = 'Debian'
             end
 
             case architecture
@@ -41,6 +46,7 @@ describe 'mariadbrepo' do
               {
                 :operatingsystem        => operatingsystem,
                 :operatingsystemrelease => vers_full,
+                :osfamily               => osfamily,
                 :architecture           => architecture,
                 :lsbdistcodename        => codename,
                 :lsbdistid              => "#{operatingsystem}"
@@ -68,12 +74,14 @@ describe 'mariadbrepo' do
             when
               it {
                 should contain_apt__source('MariaDB').with({
-                  'ensure'     => package_ensure,
-                  'location'   => "http://ftp.osuosl.org/pub/mariadb/repo/#{mariadb_release}/#{os}",
-                  'release'    => "#{codename}",
-                  'repos'      => 'main',
-                  'key'        => '1BB943DB',
-                  'key_server' => 'keyserver.ubuntu.com',
+                  'ensure'   => package_ensure,
+                  'location' => "http://ftp.osuosl.org/pub/mariadb/repo/#{mariadb_release}/#{os}",
+                  'release'  => "#{codename}",
+                  'repos'    => 'main',
+                  'key'      => {
+                    'id'     => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
+                    'server' => 'keyserver.ubuntu.com',
+                  },
                 })
               }
             end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,14 +23,15 @@ RSpec.configure do |c|
 
   # Readable test descriptions
   c.formatter = :documentation
-  
+
   # Configure all nodes in nodeset
   c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'mariadbrepo')
     hosts.each do |host|
-      on host, "mkdir -p #{host['distmoduledir']}/mariadbrepo"
-      %w(manifests metadata.json).each do |file|
-        scp_to host, "#{proj_root}/#{file}", "#{host['distmoduledir']}/mariadbrepo"
-      end
+      # Needed for the consul module to download the binary per the modulefile
+      on host, puppet('module', 'install', 'puppetlabs/stdlib', '--version', '4.9.0'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs/apt', '--version', '2.2.0'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
The puppetlabs-apt module [had introduced backwards-incompatible changes](https://forge.puppetlabs.com/puppetlabs/apt/changelog) from version 2.0.0. The 2.2.0 is right now the latest stable version and the 2.X.X versions are more popular making this module no compatible with many modules that depends on the same library. 

I have also fixed the acceptance tests for ubuntu/debian because they were failing when trying to ensure that a yum repo were installed on a Debian machine :P 
