### PR TITLE
Avoid warning with apt repository

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class mariadbrepo (
         location   => "${mirror}/repo/${version}/${os}",
         release    => $::lsbdistcodename,
         repos      => 'main',
-        key        => '1BB943DB',
+        key        => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
         key_server => 'keyserver.ubuntu.com',
       }
     }

--- a/spec/classes/mariadbrepo_spec.rb
+++ b/spec/classes/mariadbrepo_spec.rb
@@ -72,7 +72,7 @@ describe 'mariadbrepo' do
                   'location'   => "http://ftp.osuosl.org/pub/mariadb/repo/#{mariadb_release}/#{os}",
                   'release'    => "#{codename}",
                   'repos'      => 'main',
-                  'key'        => '1BB943DB',
+                  'key'        => '199369E5404BD5FC7D2FE43BCBCB082A1BB943DB',
                   'key_server' => 'keyserver.ubuntu.com',
                 })
               }


### PR DESCRIPTION
/Apt_key[Add key: 1BB943DB from Apt::Source MariaDB]: The id should be a full fingerprint (40 characters), see README.
