### PR TITLE
allow puppetlabs/apt < 3.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: '3.2.1'
     'apt':
       repo: 'https://github.com/puppetlabs/puppetlabs-apt.git'
-      ref: '1.7.0'
+      ref: '2.3.0'
   symlinks:
     "mariadbrepo": "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 1.7.0 < 3.0.0"
     }
   ]
 }

--- a/spec/classes/mariadbrepo_spec.rb
+++ b/spec/classes/mariadbrepo_spec.rb
@@ -43,7 +43,9 @@ describe 'mariadbrepo' do
                 :operatingsystemrelease => vers_full,
                 :architecture           => architecture,
                 :lsbdistcodename        => codename,
-                :lsbdistid              => "#{operatingsystem}"
+                :lsbdistid              => "#{operatingsystem}",
+                :osfamily               =>
+                  operatingsystem =~ /(Debian|Ubuntu)/ ? 'Debian' : 'RedHat',
               }
             end
 


### PR DESCRIPTION
With the exception of the 2.1.0 release, 2.x is guaranteed to be
compatible with the 1.x API.